### PR TITLE
adding init.sh for multiple chains and relayer script

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1,0 +1,29 @@
+
+### Chain 1
+icad keys add val --home ~/.demo-test-1
+
+icad init --chain-id test-1 test-1 --home ~/.demo-test-1
+
+sed -i -e 's/2665/1665/g' ~/.demo-test-1/config/config.toml
+sed -i -e 's#localhost:6060#localhost:6061#g' ~/.demo-test-1/config/config.toml
+sed -i -e 's#address = "0.0.0.0:9090"#address = "0.0.0.0:9092"#g' ~/.demo-test-1/config/app.toml
+#sed -i -e 's#localhost:6060#localhost:6061#g' ~/.demo-test-1/config/config.toml
+
+icad add-genesis-account $(icad keys show val -a --home ~/.demo-test-1) 100000000000stake --home ~/.demo-test-1
+icad gentx val 7000000000stake --chain-id test-1 --home ~/.demo-test-1
+
+icad collect-gentxs --home ~/.demo-test-1
+
+### Chain 2
+icad keys add val2 --home ~/.demo-test-2
+
+icad init --chain-id test-2 test-2 --home ~/.demo-test-2
+
+icad add-genesis-account $(icad keys show val2 -a --home ~/.demo-test-2) 100000000000stake --home ~/.demo-test-2
+icad gentx val2 7000000000stake --chain-id test-2 --home ~/.demo-test-2
+
+icad collect-gentxs --home ~/.demo-test-2
+
+#echo "Running both chains"
+icad start --pruning nothing --home ~/.demo-test-1 &
+icad start --pruning nothing --home ~/.demo-test-2 &

--- a/rly/interchain-acc-config/chains/test-1.json
+++ b/rly/interchain-acc-config/chains/test-1.json
@@ -1,0 +1,12 @@
+{
+  "key": "test-1",
+  "chain-id": "test-1",
+  "rpc-addr": "http://127.0.0.1:16657",
+  "account-prefix": "cosmos",
+  "gas-prices": "0.0025stake",
+  "default-denom": "stake",
+  "gas-adjustment":1.5,
+  "gas":900000,
+  "trusting-period": "330h"
+}
+

--- a/rly/interchain-acc-config/chains/test-2.json
+++ b/rly/interchain-acc-config/chains/test-2.json
@@ -1,0 +1,12 @@
+{
+  "key": "test-2",
+  "chain-id": "test-2",
+  "rpc-addr": "http://127.0.0.1:26657",
+  "account-prefix": "cosmos",
+  "gas-prices": "0.0025stake",
+  "default-denom": "stake",
+  "gas-adjustment":1.5,
+  "gas":900000,
+  "trusting-period": "330h"
+}
+

--- a/rly/interchain-acc-config/paths/test1-account-test2.json
+++ b/rly/interchain-acc-config/paths/test1-account-test2.json
@@ -1,0 +1,25 @@
+{
+  "src": {
+    "chain-id": "test-1",
+    "client-id": "",
+    "connection-id": "",
+    "channel-id": "",
+    "port-id": "ibcaccount",
+    "order": "ordered",
+    "version": "ics27-1"
+  },
+  "dst": {
+    "chain-id": "test-2",
+    "client-id": "",
+    "connection-id": "",
+    "channel-id": "",
+    "port-id": "ibcaccount",
+    "order": "ordered",
+    "version": "ics27-1"
+  },
+  "strategy": {
+    "type": "naive"
+  }
+}
+
+

--- a/rly/interchain-acc-config/rly.sh
+++ b/rly/interchain-acc-config/rly.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+rly config init
+
+rly config add-chains ./chains
+rly config add-paths ./paths
+
+rly keys restore test-1 test-1 "<mnemonic>"
+
+rly keys restore test-2 test-2 "<mnemonic>"
+
+rly light init test-1 -f
+rly light init test-2 -f
+
+rly tx path test1-account-test2
+
+rly start test1-account-test2
+


### PR DESCRIPTION
Adding scripts to start up multiple blockchains with a relayer. 

Run the blockchains with `init.sh` and add the mnemonics to the `rly.sh` script. 

Example output of the relayer running with both chains:

![Selection_001](https://user-images.githubusercontent.com/12762594/110129859-b6e00d00-7dc8-11eb-83df-df442cf01f91.png)
